### PR TITLE
Create `env` for skipping mapped rows that fail validation

### DIFF
--- a/adapters/hardcover.py
+++ b/adapters/hardcover.py
@@ -112,7 +112,7 @@ def map_row(row, strategy="default", idx=None, total=None):
                 notes = row.get("Private Notes")
                 
             case _:
-                log(f"[hardcover.py.map_row] Unknown strategy = {strategy}",VERBOSITY_ERROR)
+                log(f"[hardcover.py.map_row] Unknown or unsupported strategy = {strategy}",VERBOSITY_ERROR)
                 log(f"[hardcover.py.map_row] Mapping media_type from Media: {media_type}", VERBOSITY_TRACE)
                 return []
 

--- a/adapters/hardcover.py
+++ b/adapters/hardcover.py
@@ -24,9 +24,9 @@ Full Column List as of 2025-07-10: Title,Author,Series,Status,Privacy,Hardcover 
 """
 
 from clilog import log, VERBOSITY, VERBOSITY_ERROR, VERBOSITY_WARNING, VERBOSITY_INFO, VERBOSITY_DEBUG, VERBOSITY_TRACE
-from .validate import validate_row
+from .validate import validate_row, skip_invalid_row
 
-def map_row(row, idx=None, total=None):
+def map_row(row, strategy="default", idx=None, total=None):
     """
     Map a single hardcover row dict to the target schema.
     Optionally logs the row index and total.
@@ -34,96 +34,142 @@ def map_row(row, idx=None, total=None):
     log(f"[hardcover.py.map_row] =========================", VERBOSITY_DEBUG)
     if idx is not None and total is not None:
         log(f"[hardcover.py.map_row] Mapping row {idx}/{total}", VERBOSITY_DEBUG)
-    column_name=None
+    log(f"[hardcover.py.map_row] Row {idx}: {row}", VERBOSITY_TRACE)
+    
+    source="hardcover"
+    media_id=None
+    media_type="book"
+    title=None
+    image=None
+    season_number=None
+    episode_number=None
+    score=None
+    status="Planning"
+    notes=None
+    start_date=None
+    end_date=None
+    progress=None
 
     try:
-        # Map media_type
-        column_name="media_type"
-        media_type = row.get("Media", "").lower()
-        log(f"[hardcover.py.map_row] Mapping media_type from Media: {media_type}", VERBOSITY_TRACE)
-        if media_type in ("book", "audio", "ebook"):
-            mapped_media_type = "book"
-            log(f"[hardcover.py.map_row] Mapped media_type to 'book'", VERBOSITY_TRACE)
-        elif media_type == "comic":
-            mapped_media_type = "comic"
-            log(f"[hardcover.py.map_row] Mapped media_type to 'comic'", VERBOSITY_TRACE)
-        else:
-            mapped_media_type = media_type or None
-            log(f"[hardcover.py.map_row] mapped_media_type to None or original value: {mapped_media_type}", VERBOSITY_WARNING)
+        match strategy:
+            case "default":
+                media_id=row.get("Hardcover Book ID")
+                log(f"[hardcover.py.map_row] Media ID: {media_id}", VERBOSITY_TRACE)
+                
+                status=row.get("Status").lower()
+                log(f"[hardcover.py.map_row] Hardcover status: {status}", VERBOSITY_TRACE)\
+                
+                match status:
+                    case "read":
+                        status = "Completed"
+                        log (f"[hardcover.py.map_row] Status mapped to Completed", VERBOSITY_TRACE)
+                    case "want to read":
+                        status = "Planning"
+                        log (f"[hardcover.py.map_row] Status mapped to In progress", VERBOSITY_TRACE)
+                    case "currently reading":
+                        status = "In progress"
+                        log (f"[hardcover.py.map_row] Status mapped to Planning", VERBOSITY_TRACE)
+                    case _:
+                        log(f"[hardcover.py.map_row] Bookshelf status not a default bookshelf name: {status}.", VERBOSITY_WARNING)
+                        status = "In progress"
+                        log(f"[hardcover.py.map_row] Status defaulting to In progress", VERBOSITY_TRACE)
+                
+                media_type = row.get("Media", "").lower()
+                if media_type in ("book", "audio", "ebook"):
+                    media_type = "book"
+                    log(f"[hardcover.py.map_row] Mapped media_type to 'book'", VERBOSITY_TRACE)
+                    progress = row.get("Pages")
+                elif media_type == "comic":
+                    media_type = "comic"
+                    log(f"[hardcover.py.map_row] Mapped media_type to 'comic'", VERBOSITY_TRACE)
+                else:
+                    log(f"[hardcover.py.map_row] Unable to map media_type, defaulting to 'book'", VERBOSITY_WARNING)
+                
 
-        # Map status
-        column_name="status"
-        log(f"[hardcover.py.map_row] Mapping status from Status: {row.get('Status', '')}", VERBOSITY_TRACE)
-        status_map = {
-            "Read": "Completed",
-            "Want to Read": "Planning",
-            "Currently Reading": "In progress"
-        }
-        mapped_status = status_map.get(row.get("Status", ""), row.get("Status", ""))
-        log(f"[hardcover.py.map_row] Mapped status: {mapped_status}", VERBOSITY_TRACE)
 
-        # Map score
-        column_name="score"
-        log(f"[hardcover.py.map_row] Mapping score from Rating: {row.get('Rating', 0)}", VERBOSITY_TRACE)
-        try:
-            score = float(row.get("Rating", 0)) * 2
-        except Exception:
-            score = None
-        log(f"[hardcover.py.map_row] Mapped score: {score}", VERBOSITY_TRACE)
+                log(f"[hardcover.py.map_row] Mapping score from Rating: {row.get('Rating')}", VERBOSITY_TRACE)
+                try:
+                    score = row.get("Rating")
+                    if score:
+                        score = float(score) * 2
+                    else:
+                        score = None
+                except Exception:
+                    log("[hardcover.py.map_row] Unable to calculate score, defaulting to None", VERBOSITY_WARNING)
+                    score = None
+                log(f"[hardcover.py.map_row] Mapped score: {score}", VERBOSITY_TRACE)
 
-        # Map dates 
-        column_name="start_date"
-        log(f"[hardcover.py.map_row] Mapping start_date from Date Started: {row.get('Date Started')}", VERBOSITY_TRACE)
-        start_date_raw = row.get("Date Started")
-        start_date = f"{start_date_raw} 00:00:00+00:00" if start_date_raw else None
-        log(f"[hardcover.py.map_row] Mapped start_date: {start_date}", VERBOSITY_TRACE)
-        column_name="end_date"
-        log(f"[hardcover.py.map_row] Mapping end_date from Date Finished: {row.get('Date Finished')}", VERBOSITY_TRACE)
-        end_date_raw = row.get("Date Finished")
-        end_date = f"{end_date_raw} 00:00:00+00:00" if end_date_raw else None
-        log(f"[hardcover.py.map_row] Mapped end_date: {end_date}", VERBOSITY_TRACE)
+                log(f"[hardcover.py.map_row] Mapping start_date from Date Started: {row.get('Date Started')}", VERBOSITY_TRACE)
+                start_date_raw = row.get("Date Started")
+                start_date = f"{start_date_raw} 00:00:00+00:00" if start_date_raw else None
+                log(f"[hardcover.py.map_row] Mapped start_date: {start_date}", VERBOSITY_TRACE)
+
+                log(f"[hardcover.py.map_row] Mapping end_date from Date Finished: {row.get('Date Finished')}", VERBOSITY_TRACE)
+                end_date_raw = row.get("Date Finished")
+                end_date = f"{end_date_raw} 00:00:00+00:00" if end_date_raw else None
+                log(f"[hardcover.py.map_row] Mapped end_date: {end_date}", VERBOSITY_TRACE)
+
+                notes = row.get("Private Notes")
+                
+            case _:
+                log(f"[hardcover.py.map_row] Unknown strategy = {strategy}",VERBOSITY_ERROR)
+                log(f"[hardcover.py.map_row] Mapping media_type from Media: {media_type}", VERBOSITY_TRACE)
+                return []
+
     except Exception:
-        log(f"[hardcover.py.map_row] Error mapping column '{column_name}' in row {idx}. Writing as is.", VERBOSITY_ERROR)
+        log(f"[hardcover.py.map_row] Error mapping row with strategy '{strategy}' in row {idx}. Writing as is.", VERBOSITY_ERROR)
 
     try:
         # Build mapped row
         mapped = {
             "source": "hardcover",
-            "media_id": row.get("Hardcover Book ID"),
-            "media_type": mapped_media_type,
+            "media_id": media_id,
+            "media_type": media_type,
             "title": None,
             "image": None,
             "season_number": None,
             "episode_number": None,
             "score": score,
-            "status": mapped_status,
-            "notes": row.get("Private Notes"),
+            "status": status,
+            "notes": notes,
             "start_date": start_date,
             "end_date": end_date,
-            "progress": row.get("Pages"),
+            "progress": progress,
         }
         
         valid = validate_row(mapped)
         if valid:
             log(f"[hardcover.py.map_row] Mapped row: {mapped}", VERBOSITY_DEBUG)
+        else:
+            log(f"[hardcover.py.map_row] Row {idx}: {mapped}", VERBOSITY_WARNING)
+            if skip_invalid_row:
+                log(f"skip_invalid_row is true, will not export row {idx}", VERBOSITY_INFO)
+                return []
         return mapped
     except Exception:
         log(f"[hardcover.py.map_row] Failed to build mapped row for row {idx}", VERBOSITY_ERROR)
         return []
 
-def process_rows(rows):
+def process_rows(rows,strategy="default"):
     """
     Process a list of dictionaries representing rows from the hardcover CSV.
     Returns a list of mapped rows.
     """
-    log(f"[hardcover.py.process_rows] ==============================================", VERBOSITY_DEBUG)
-    log(f"[hardcover.py.process_rows] Processing {len(rows)} rows from hardcover", VERBOSITY_DEBUG)
     try:
+        log(f"[hardcover.py.process_rows] ==============================================", VERBOSITY_DEBUG)
+        log(f"[hardcover.py.process_rows] Processing {len(rows)} rows from hardcover", VERBOSITY_DEBUG)
         if rows:
             total = len(rows)
-            mapped_rows = [map_row(row, idx+1, total) for idx, row in enumerate(rows)]
-            log(f"[hardcover.py.process_rows] Mapped all rows", VERBOSITY_DEBUG)
+            mapped_rows = []
+            for idx, row in enumerate(rows):
+                mapped = map_row(row, strategy, idx + 1, total)
+                # Skip if mapped is None or empty list
+                if mapped is None or mapped == []:
+                    log(f"[hardcover.py.process_rows] Detected empty row in {idx + 1}", VERBOSITY_DEBUG)
+                    continue
+                mapped_rows.append(mapped)
             log(f"[hardcover.py.process_rows] =========================", VERBOSITY_DEBUG)
+            log("[hardcover.py.process_rows] Mapped all rows", VERBOSITY_DEBUG)
             return mapped_rows
     except Exception:
         log(f"[hardcover.py.process_rows] Critical error processing rows", VERBOSITY_ERROR)

--- a/adapters/igdb.py
+++ b/adapters/igdb.py
@@ -53,7 +53,7 @@ Full Column List as of 2025-07-10: id, game, url, rating, category, release_date
 from clilog import log, VERBOSITY, VERBOSITY_ERROR, VERBOSITY_WARNING, VERBOSITY_INFO, VERBOSITY_DEBUG, VERBOSITY_TRACE
 from .validate import validate_row, skip_invalid_row
 
-def map_row(row, strategy=None, idx=None, total=None):
+def map_row(row, strategy="default", idx=None, total=None):
     """
     Map a single igdb row dict to the target schema.
     Optionally logs the row index and total.
@@ -95,12 +95,12 @@ def map_row(row, strategy=None, idx=None, total=None):
                 # Strategy set if `--strategy` is none and input file was `want-to-play.csv`
                 media_id=row.get("id")
                 status="Planning"
-            case "igdb":
+            case "default":
                 # Default if `--source` is `igdb`
                 media_id=row.get("id")
                 title=row.get("game")
             case _:
-                log(f"[igdb.py.map_row] Unknown strategy = {strategy}",VERBOSITY_ERROR)
+                log(f"[igdb.py.map_row] Unknown or unsupported strategy = {strategy}",VERBOSITY_ERROR)
                 return []
     except Exception:
         log(f"[igdb.py.map_row] Error mapping row with strategy '{strategy}' in row {idx}. Writing as is.", VERBOSITY_ERROR)
@@ -137,7 +137,7 @@ def map_row(row, strategy=None, idx=None, total=None):
         return []
     
 
-def process_rows(rows,strategy=None):
+def process_rows(rows,strategy="default"):
     """
     Process a list of dictionaries representing rows from the file.
     Returns a list of mapped rows.

--- a/adapters/openlibrary.py
+++ b/adapters/openlibrary.py
@@ -31,7 +31,7 @@ Full Column List as of 2025-07-13: Work ID, Title, Authors, First Publish Year, 
 from clilog import log, VERBOSITY, VERBOSITY_ERROR, VERBOSITY_WARNING, VERBOSITY_INFO, VERBOSITY_DEBUG, VERBOSITY_TRACE
 from .validate import validate_row, skip_invalid_row
 
-def map_row(row, strategy=None, idx=None, total=None):
+def map_row(row, strategy="default", idx=None, total=None):
     """
     Map a single openlibrary row dict to the target schema.
     Optionally logs the row index and total.
@@ -57,7 +57,8 @@ def map_row(row, strategy=None, idx=None, total=None):
 
     try:
         match strategy:
-            case "openlibrary-reading-log":
+            case "default":
+            #case "openlibrary-reading-log":
                 # Stretegy set if `--strategy` is none and input file was `OpenLibrary_ReadingLog.csv`
                 media_id=row.get("Edition ID")
                 log(f"[openlibrary.py.map_row] Media ID: {media_id}", VERBOSITY_TRACE)
@@ -94,7 +95,7 @@ def map_row(row, strategy=None, idx=None, total=None):
                     log("[openlibrary.py.map_row] No My Ratings found, score will be None", VERBOSITY_TRACE)
                     score = None
             case _:
-                log(f"[openlibrary.py.map_row] Unknown strategy = {strategy}",VERBOSITY_ERROR)
+                log(f"[openlibrary.py.map_row] Unknown or unsupported strategy = {strategy}",VERBOSITY_ERROR)
                 return []
     except Exception:
         log(f"[openlibrary.py.map_row] Error mapping row with strategy '{strategy}' in row {idx}. Writing as is.", VERBOSITY_ERROR)
@@ -131,7 +132,7 @@ def map_row(row, strategy=None, idx=None, total=None):
         return []
     
 
-def process_rows(rows,strategy=None):
+def process_rows(rows,strategy="default"):
     """
     Process a list of dictionaries representing rows from the file.
     Returns a list of mapped rows.

--- a/adapters/openlibrary.py
+++ b/adapters/openlibrary.py
@@ -29,7 +29,7 @@ Full Column List as of 2025-07-13: Work ID, Title, Authors, First Publish Year, 
 """
 
 from clilog import log, VERBOSITY, VERBOSITY_ERROR, VERBOSITY_WARNING, VERBOSITY_INFO, VERBOSITY_DEBUG, VERBOSITY_TRACE
-from .validate import validate_row
+from .validate import validate_row, skip_invalid_row
 
 def map_row(row, strategy=None, idx=None, total=None):
     """
@@ -39,6 +39,7 @@ def map_row(row, strategy=None, idx=None, total=None):
     log(f"[openlibrary.py.map_row] =========================", VERBOSITY_DEBUG)
     if idx is not None and total is not None:
         log(f"[openlibrary.py.map_row] Mapping row {idx}/{total}", VERBOSITY_DEBUG)
+    log(f"[openlibrary.py.map_row] Row {idx}: {row}", VERBOSITY_TRACE)
 
     source="openlibrary"
     media_id=None
@@ -94,7 +95,7 @@ def map_row(row, strategy=None, idx=None, total=None):
                     score = None
             case _:
                 log(f"[openlibrary.py.map_row] Unknown strategy = {strategy}",VERBOSITY_ERROR)
-                return "Unknown Souce"
+                return []
     except Exception:
         log(f"[openlibrary.py.map_row] Error mapping row with strategy '{strategy}' in row {idx}. Writing as is.", VERBOSITY_ERROR)
 
@@ -119,6 +120,11 @@ def map_row(row, strategy=None, idx=None, total=None):
         valid = validate_row(mapped)
         if valid:
             log(f"[openlibrary.py.map_row] Mapped row: {mapped}", VERBOSITY_DEBUG)
+        else:
+            log(f"[openlibrary.py.map_row] Row {idx}: {mapped}", VERBOSITY_WARNING)
+            if skip_invalid_row:
+                log(f"skip_invalid_row is true, will not export row {idx}", VERBOSITY_INFO)
+                return []
         return mapped
     except Exception:
         log(f"[openlibrary.py.map_row] Failed to build mapped row for row {idx}", VERBOSITY_ERROR)
@@ -136,7 +142,14 @@ def process_rows(rows,strategy=None):
         log(f"[openlibrary.py.process_rows] Strategy being used = {strategy}", VERBOSITY_DEBUG)
         if rows:
             total = len(rows)
-            mapped_rows = [map_row(row, strategy, idx+1, total) for idx, row in enumerate(rows)]
+            mapped_rows = []
+            for idx, row in enumerate(rows):
+                mapped = map_row(row, strategy, idx + 1, total)
+                # Skip if mapped is None or empty list
+                if mapped is None or mapped == []:
+                    log(f"[openlibrary.py.process_rows] Detected empty row in {idx + 1}", VERBOSITY_DEBUG)
+                    continue
+                mapped_rows.append(mapped)
             log(f"[openlibrary.py.process_rows] =========================", VERBOSITY_DEBUG)
             log("[openlibrary.py.process_rows] Mapped all rows", VERBOSITY_DEBUG)
             return mapped_rows

--- a/adapters/validate.py
+++ b/adapters/validate.py
@@ -6,8 +6,17 @@ Reference: https://github.com/FuzzyGrim/Yamtrack/wiki/Yamtrack-CSV-Format
 
 from datetime import datetime
 from typing import Any, Dict, Tuple
+import os
+from dotenv import load_dotenv
+from pathlib import Path
 
 from clilog import log, VERBOSITY, VERBOSITY_WARNING, VERBOSITY_WARNING, VERBOSITY_INFO, VERBOSITY_DEBUG, VERBOSITY_TRACE, VERBOSITY_ERROR
+
+# Variable defenitions
+ENV_PATH = Path(__file__).parent / '.env'
+load_dotenv(dotenv_path=ENV_PATH)
+
+skip_invalid_row = os.getenv("skip_invalid_row", "False").lower() in ("true", "1", "yes")
 
 # === YamTrack static rule sets =================================================
 

--- a/cli.py
+++ b/cli.py
@@ -173,7 +173,9 @@ def main():
 
     try:
         # Detect file name based on source and suggest strategy
+        
         if strategy is None:
+            strategy = "default"
             if filetype == 'csv':
                 if args.source == 'igdb':
                     if file_name.endswith('played.csv'):
@@ -189,9 +191,7 @@ def main():
                     if file_name.endswith('openlibrary_readinglog.csv'):
                         log("[cli.py.main] Detected OpenLibrary reading log CSV", VERBOSITY_DEBUG)
                         strategy = 'openlibrary-reading-log'
-            else:
-                # default strategy to the source value
-                strategy = args.source
+
         log(f"[cli.py.main] Strategy: {strategy}", VERBOSITY_DEBUG)
     except Exception:
         log("[cli.py.main] Unable to set strategy", VERBOSITY_ERROR)
@@ -201,7 +201,7 @@ def main():
         if filetype == 'csv':
             rows = import_csv(input_file)
             if args.source == 'hardcover':
-                mapped_rows = hardcover.process_rows(rows)
+                mapped_rows = hardcover.process_rows(rows, strategy)
             elif args.source == 'igdb':
                 mapped_rows = igdb.process_rows(rows, strategy)
             elif args.source == 'openlibrary':

--- a/cli.py
+++ b/cli.py
@@ -172,10 +172,10 @@ def main():
         log(f"[cli.py.main] Unable to detect file type for {input_path}", VERBOSITY_ERROR)
 
     try:
-        # Detect file name based on source and suggest strategy
+        # Detect file name based on source and enforce different strategy
         
         if strategy is None:
-            strategy = "default"
+            strategy = "default" # Default to default
             if filetype == 'csv':
                 if args.source == 'igdb':
                     if file_name.endswith('played.csv'):
@@ -188,9 +188,10 @@ def main():
                         log("[cli.py.main] Detected IGDB want-to-play list CSV", VERBOSITY_DEBUG)
                         strategy = 'list-want'
                 if args.source == 'openlibrary':
-                    if file_name.endswith('openlibrary_readinglog.csv'):
-                        log("[cli.py.main] Detected OpenLibrary reading log CSV", VERBOSITY_DEBUG)
-                        strategy = 'openlibrary-reading-log'
+                    log("[cli.py.main] Placeholder logic for openlibrary exports.", VERBOSITY_TRACE)
+                    #if file_name.endswith('openlibrary_readinglog.csv'):
+                        #log("[cli.py.main] Detected OpenLibrary reading log CSV", VERBOSITY_DEBUG)
+                        #strategy = 'openlibrary-reading-log'
 
         log(f"[cli.py.main] Strategy: {strategy}", VERBOSITY_DEBUG)
     except Exception:

--- a/clilog.py
+++ b/clilog.py
@@ -82,7 +82,7 @@ def log(msg, level=None):
         traceback.print_exc()  # Prints to stderr
 
         if traceback_exit:
-            log(f"[logging.py.log] Exiting due to traceback_exit",VERBOSITY_TRACE)
+            log(f"[logging.py.log] Exiting due to traceback_exit",VERBOSITY_WARNING)
             sys.exit()
 
 def _log_to_file(msg, level):

--- a/template.env
+++ b/template.env
@@ -2,7 +2,8 @@
 verbosity=4 # 0: Error, 1: Warning, 2: Info, 3: Debug, 4: Trace
 write_to_file=True # Write logs to file
 clear_logs_on_start=True # Clear logs on startup
-#traceback_exit=False # Exits the script immediately on ERROR level verbosity messages
+traceback_exit=False # Exits the script immediately on ERROR level verbosity messages
+skip_invalid_row=False # When using adapters.validate.py, if the row fails validation do not include into yamtrack export
 # API's
     # igdb (Twitch)
         # https://dev.twitch.tv/console/apps/create


### PR DESCRIPTION
- New `env` variable `skip_invalid_row`. When being verified with `adapters.validate`, if the validation fails and this value is `True`, skips saving the row to the CSV. Defaults to `False` 
- `hardcover` adapter is more structurally identical to the other adapters
- Changed default strategy to `default` instead of `--source`