### PR TITLE
Clone `yamtrack-data-migrator.wiki.git` and create action to sync

### DIFF
--- a/.github/workflows/sync-wiki.yml
+++ b/.github/workflows/sync-wiki.yml
@@ -1,0 +1,33 @@
+name: Sync wiki to GitHub Wiki
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - 'wiki/**'
+
+jobs:
+  push-wiki:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set up Git user
+        run: |
+          git config --global user.name "github-actions[bot]"
+          git config --global user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+      - name: Clone wiki repo
+        run: |
+          git clone "https://x-access-token:${{ secrets.GITHUB_TOKEN }}@github.com/${{ github.repository }}.wiki.git" wiki_repo
+          rsync -av --delete ./wiki/ ./wiki_repo/
+          cd wiki_repo
+          git add .
+          git diff --cached --quiet || git commit -m "Automated sync from ./wiki folder"
+          git push

--- a/wiki/Exporting.md
+++ b/wiki/Exporting.md
@@ -1,0 +1,33 @@
+This page will instruct you on how to export files from source supported by this script.
+
+## Hardcover (`hardcover`) <img src="https://wp.hardcover.app/wp-content/uploads/2023/11/Symbol.png" height="50">
+
+1. Navigate to [https://hardcover.app/](https://hardcover.app/) and sign in to your account.
+    - Or use this [link](https://hardcover.app/account/exports) to skip to step 4.
+2. Hover over your profile icon on the top-right of the page, and select `Settings`.
+3. Select `Export Your Data` 
+4. Select the `Generate Export` button and their system will begin creating the export. This should be available in several seconds if you refresh your page, however you will also get a notification when it is complete.
+5. On the most recent export, click the `Download` link.
+
+## The Internet Game Database (`igdb`) <img src="https://www.igdb.com/packs/static/igdbLogo-bcd49db90003ee7cd4f4.svg" height="50">
+
+igdb provides several a couple of ways to export your data:
+
+- Lists (CSV) - Two types of lists
+    1. Status Lists - When you mark a game as `Want`, `Playing`, or `Played` from either the games main page or another list, idbh maintains a list of games with this tag. Each 'auto list' exports the csv as the lowercase version of the status. 
+    2. Custom Lists - User created lists. Lists download as the lowercase version of the list name. 
+
+1. Navigate to [https://www.igdb.com](https://www.igdb.com) and sign in to your account.
+2. Click on the drop down arrow on the top-right of the page and select `My Lists`
+3. Select a list to export
+4. Click on the `Download CSV` button
+
+## Open Library (`openlibrary`) <img src="https://openlibrary.org/static/images/openlibrary-logo-tighter.svg" height="50">
+
+Open Library has several export functions. The current one built into the default strategy is for your `Reading Log`.
+
+1. Navigate to [Open Library](https://openlibrary.org) and sign in to your account
+    - Or use this [direct link](https://openlibrary.org/account/import) and skip to step 4
+2. On the top right, expand the menu pane and select `My Books`
+3. On the left you have your different bookshelfs. Near the bottom, select `Import & Export Options`
+4. Find the `Export your Reading Log` section and click on the `Download (.csv format)` button beneath it.

--- a/wiki/Home.md
+++ b/wiki/Home.md
@@ -1,0 +1,1 @@
+Welcome to the yamtrack-data-migrator wiki!

--- a/wiki/Sources.md
+++ b/wiki/Sources.md
@@ -1,0 +1,24 @@
+# Sources to Support
+
+The following YamTrack sources do **not** support online importing but some can be exported in their own formats:
+
+| Source Name | Media Type(s) | Wiki Link |
+| --- | --- | -- |
+| [hardcover](https://hardcover.app/) | `book`, `comic` | |
+| [tmdb](https://www.themoviedb.org/) | `tv`, `season`, `episode`, `movie` | `N/A` |
+| [mangaupdates](https://www.mangaupdates.com) | `manga` | `N/A` |
+| [igdb](https://www.igdb.com/) | `game` | `N/A` |
+| [openlibrary](https://openlibrary.org/) | `book` | `N/A` |
+| [comicvine](https://comicvine.gamespot.com/) | `comic` | `N/A` |
+| manual | | `N/A` |
+
+## Already Supported Sources
+
+The following sources currently support direct import via YamTrack UI:
+
+- [myanimelist](https://myanimelist.net/) - `manga`, `anime`
+- [trakt](https://trakt.tv) - `tv`, `season`, `episode`, `movie`
+- [SIMKL](https://simkl.com/) - `tv`, `season`, `episode`, `movie`
+- [AniList](https://anilist.co) - `manga`, `anime`
+- [Kitsu](https://kitsu.app/) - `manga`, `anime`
+- [HowLongToBeat](https://howlongtobeat.com/) - `game`


### PR DESCRIPTION
Github wiki was cloned to `./wiki` and an action was created to push changes (if any) to this repo.